### PR TITLE
Add .gitattributes to get correct github statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.h linguist-language=C++


### PR DESCRIPTION
Using https://github.com/github/linguist#using-gitattributes

**Current**
<img width="983" alt="screen shot 2016-11-02 at 3 11 51 am" src="https://cloud.githubusercontent.com/assets/4310419/19901343/24eaea0a-a0aa-11e6-918a-4718814d9265.png">

**After This PR**
<img width="984" alt="screen shot 2016-11-02 at 3 10 50 am" src="https://cloud.githubusercontent.com/assets/4310419/19901322/10f65b7e-a0aa-11e6-8680-8e9171ede59b.png">
